### PR TITLE
Update processor.rs

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -147,6 +147,7 @@ impl Processor {
         }
 
         **receiver_account.try_borrow_mut_lamports()? += lamport_streamed_to_receiver;
+        **escrow_account.try_borrow_mut_lamports()? -= lamport_streamed_to_receiver;
         escrow_data.lamports_withdrawn += lamport_streamed_to_receiver;
         **sender_account.try_borrow_mut_lamports()? += **escrow_account.lamports.borrow();
 


### PR DESCRIPTION
to fix `sum of account balances before and after instruction do not match`. Indeed, `lamport_streamed_to_receiver` added to the receiver must be subtracted from the escrow before the remaining lamports from the escrow are sent to the sender.

btw: thanks for the tutorial on Figment, it's been very helpful to understand Solana more in details.